### PR TITLE
fix: typo in all for winex86

### DIFF
--- a/armbian-gaming.sh
+++ b/armbian-gaming.sh
@@ -122,7 +122,7 @@ function box64 {
 function all {
 	box86
 	box64
-	wine86
+	winex86
 }
 
  


### PR DESCRIPTION
Fixed a typo in the function `all` for wineX86 installation.